### PR TITLE
Add PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ List ordering follows [TIOBE Index](https://www.tiobe.com/tiobe-index/).
 | [JavaScript](#javascript) | [`Math`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math) | [`Math.floor(Math.random() * 10) + 1`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/random) | `Math.random() * 100` |
 | Assembly |
 | [PHP](#php) | [Math](https://www.php.net/manual/en/book.math.php) (core) | [`mt_rand(1, 10)`](https://www.php.net/manual/function.rand.php) | [`mt_rand() / (float)(mt_getrandmax() + 1) * 100`](https://www.php.net/manual/en/function.mt-getrandmax.php) |
-| SQL |
+| SQL (PostgreSQL) | - | `SELECT TRUNC(RANDOM() * 10) + 1` | `SELECT RANDOM() * 100` |
 | Ruby |
 | Go |
 | Swift |


### PR DESCRIPTION
Adding entry for PostgreSQL. Random function is not present in ANSI SQL standard and should be specified in accordance with respective implementations. (For instance, random function in MySQL is `RAND()`)